### PR TITLE
adding overlay options for stcs graphic overlays

### DIFF
--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -1007,7 +1007,7 @@ class Aladin(anywidget.AnyWidget):
             {
                 "event_name": "add_overlay",
                 "regions_infos": regions_infos,
-                "graphic_options": {},
+                "graphic_options": overlay_options,
             }
         )
 


### PR DESCRIPTION
Passing along missing dictionary to be able to specify overlay options in `add_graphic_overlay_from_stcs`