### PR TITLE
CST-306: update edge cases of rotation, target, and fov updates

### DIFF
--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -94,6 +94,11 @@ export default class EventHandler {
         return;
       }
       jsTargetLock.lock();
+
+      if (this.aladin.view.dragging) {
+        return;
+      }
+
       const raDec = [position.ra, position.dec];
       this.updateWCS();
       this.model.set("_target", `${raDec[0]} ${raDec[1]}`);
@@ -122,6 +127,12 @@ export default class EventHandler {
       }
       jsFovLock.lock();
       // fov MUST be cast into float in order to be sent to the model
+
+      const zoom = this.aladin.view.zoom;
+      if (zoom.isZooming && fov != zoom.finalZoom) {
+        return;
+      }
+
       this.updateWCS();
       this.update2AxisFoV();
       this.model.set("_fov", parseFloat(fov.toFixed(5)));

--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -160,7 +160,6 @@ export default class EventHandler {
 
     /* Rotation control */
     this.model.on("change:_rotation", () => {
-      this.updateRotation(this.model.get("_rotation"), this.aladinDiv);
       // Update WCS and FoV only if this is the last div
       this.updateWCS();
       this.update2AxisFoV();

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -345,8 +345,6 @@ class Aladin(anywidget.AnyWidget):
             rotation = rotation.deg
         if np.isclose(self._rotation, rotation):
             return
-        self._wcs = {}
-        self._fov_xy = {}
         self._rotation = rotation
         self.send({"event_name": "change_rotation", "rotation": rotation})
 


### PR DESCRIPTION
### What is changing?
update edge cases of rotation, target, and fov updates

### Why is this change needed?
#### Reduced multi updates 
When a`ladin-lite` is updating the `target` or `fov`, it plays an animation that triggers a callback event at intermediate `target`/`fov` values between the starting and destination values. If a user listens for these callback events, they end up with a very jittery sequence of events, eventually winding up at the correct `target`/`fov`. By limiting the updates to the ipyaladin `_target` and `_fov` parameters in `event_handler.json` to only the final event in that chain, we are able to eliminate virtually all of the jitter, and the user only gets a callback on the final destination of the `target`/`fov`.

**Before:**

https://github.com/user-attachments/assets/9f81473c-ae22-487e-bc1d-87f54ed143dd

**After:**

https://github.com/user-attachments/assets/ae7fdf86-4554-4053-91d4-a844719dea70

#### Rotation updates
while testing this code, it was identified that when the rotation is updated from the API, it can get into a weird edge case where the `_fov_xy` doesn't get reset before the rotation gets set, which causes the whole thing to error out. By removing the zeroing out of `_fov_xy` we don't run into this issue anymore. It wasn't playing a part in how `rotation` or `fov_xy` was being updated, so this shouldn't be breaking any other workflows.

It was also identified that a call to `updateRotation` was being called after the rotation was already updated by the python code. This effectively meant that `widget.js` would update `rotation`, and trigger `aladin-lite` to update `rotation`. `aladin-lite` would then trigger a `change:_rotation` event which would update `rotation` again, but with an outdated value.

**Before:**
<img width="1120" height="733" alt="pre-rotation-fix" src="https://github.com/user-attachments/assets/a59b6a18-3854-435f-9562-28298fb88f4d" />

**After**
<img width="1120" height="733" alt="post-rotation-fix" src="https://github.com/user-attachments/assets/09e2a56e-9c9b-490f-a21a-7e3370a18406" />

