### PR TITLE
Don't access current_overlays listener unless it exists.

### DIFF
--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -264,12 +264,10 @@ class Aladin(anywidget.AnyWidget):
             self.listener_callback["select"](message["content"])
         elif event_type == "save_view_as_image":
             self._save_file(message["path"], buffers[0])
-        elif (
-            event_type == "current_overlays"
-            and "current_overlays" in self.listener_callback
-        ):
+        elif event_type == "current_overlays":
             self._overlays = message["content"]["overlays"]
-            self.listener_callback["current_overlays"](message["content"])
+            if "current_overlays" in self.listener_callback:
+                self.listener_callback["current_overlays"](message["content"])
 
     @property
     def selected_objects(self) -> List[Table]:

--- a/src/ipyaladin/widget.py
+++ b/src/ipyaladin/widget.py
@@ -264,7 +264,10 @@ class Aladin(anywidget.AnyWidget):
             self.listener_callback["select"](message["content"])
         elif event_type == "save_view_as_image":
             self._save_file(message["path"], buffers[0])
-        elif event_type == "current_overlays":
+        elif (
+            event_type == "current_overlays"
+            and "current_overlays" in self.listener_callback
+        ):
             self._overlays = message["content"]["overlays"]
             self.listener_callback["current_overlays"](message["content"])
 


### PR DESCRIPTION
If there is no registered listener for the `current_overlays` event, then calling `remove_overlay()` results in a `KeyError` at ipyaladin:widget.py:269 because it tries to access the non-existent listener for `current_overlays`.  

The `current_overlays` event also updates `self._overlays` and that should still happen regardless of whether a listener is registered, so the listener check should happen after that update.

A separate issue I noticed is that although `self._overlays` is updated on layer removal (via `handleRemoveOverlay()` calling `handleGetOverlays()` in message_handler.js), `self._overlays` is not updated when a layer is added.  Those adds are not as centralized as removals.  It's not clear whether it would be best to call the JS `handleGetOverlays()` on every sort of overlay add or to call the Python version in the relevant add methods.