### PR TITLE
Limit the number of repeated calls made to update the `_target` and `_fov` traitlets 

### DIFF
--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -99,7 +99,7 @@ export default class EventHandler {
       }
       jsTargetLock.lock();
 
-      // ensure we only update the view once dragging is completed
+      // only update `_target` once dragging is completed
       if (this.aladin.view.dragging) {
         return;
       }
@@ -135,7 +135,7 @@ export default class EventHandler {
       }
       jsFovLock.lock();
 
-      // ensure we only update the view once zooming is compelte
+      // only update `_fov` once zooming is compelte
       const zoom = this.aladin.view.zoom;
       if (zoom.isZooming && fov != zoom.finalZoom) {
         return;

--- a/js/models/event_handler.js
+++ b/js/models/event_handler.js
@@ -98,6 +98,12 @@ export default class EventHandler {
         return;
       }
       jsTargetLock.lock();
+
+      // ensure we only update the view once dragging is completed
+      if (this.aladin.view.dragging) {
+        return;
+      }
+
       const raDec = [position.ra, position.dec];
       this.updateWCS();
       // When dragging the view, north to east position angle might changes because
@@ -128,6 +134,13 @@ export default class EventHandler {
         return;
       }
       jsFovLock.lock();
+
+      // ensure we only update the view once zooming is compelte
+      const zoom = this.aladin.view.zoom;
+      if (zoom.isZooming && fov != zoom.finalZoom) {
+        return;
+      }
+
       // fov MUST be cast into float in order to be sent to the model
       this.updateWCS();
       this.update2AxisFoV();


### PR DESCRIPTION
### What is changing?
Limit the number of repeated calls made to update the `_target` and `_fov` traitlets 

### Why is this needed?
When aladin-lite updates its view, it does so with a smooth animation which updates the fov and target at intervals between the starting and final values to create a smooth animation. This causes issues for attached listeners on the ipyaladin traitlets that are updates as they get triggered for every intermediary value. By limiting to just updating on the final values we can avoid these extra calls. 

This is particularly important for reducing the jitter between ipyaladin and imviz when syncing as see in the demo below. As you can see in the demo, its still not perfect, but its greatly improved thanks to this change.

**Before:**

https://github.com/user-attachments/assets/8f721e4d-2682-487c-be1d-64b4560cf41b

**After:**

https://github.com/user-attachments/assets/ef0e473b-e702-42d8-80dc-5eb524027253

